### PR TITLE
Fix hologram placement and opacity

### DIFF
--- a/script.js
+++ b/script.js
@@ -151,7 +151,7 @@ function handleOrientationMain(e) {
 
   // Opacity ranges from 0.5 (flat) to 0.9 at ~35° right tilt
   let opacity = 0.5;
-  if (y > 0) {
+  if (y >= 0) {
     opacity = Math.min(0.5 + (y / 35) * 0.4, 0.9);
   }
   holo.style.backgroundColor = `rgba(0, 0, 0, ${opacity})`;

--- a/styles.css
+++ b/styles.css
@@ -131,13 +131,13 @@ html, body {
 /* Main screen hologram overrides */
 #main-screen .holo-container {
   position: absolute;
-  top: 50px;
-  bottom: 50px;
-  right: -50%;
-  height: calc(100% - 100px);
-  aspect-ratio: 1 / 1;
-  width: auto;
+  top: 50%;
+  left: 50%;
+  width: 200px;
+  height: 200px;
+  transform: translate(-50%, -50%);
   margin: 0;
+  z-index: 0;
 }
 #holo-main {
   width: 100%;


### PR DESCRIPTION
## Summary
- center the main hologram and size it to 200x200
- fade hologram opacity from 0.5 when flat to 0.9 at gamma 35

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684061f059b0833184883093b9904e6f