### PR TITLE
Add responsive hologram text

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,10 @@
         <div class="holo-container">
           <div id="holo-main" class="holo-object"></div>
         </div>
+        <div id="holo-text" class="holo-text">
+          <div id="line-norge">NORGE</div>
+          <div id="line-noreg">NOREG</div>
+        </div>
       </div>
       <div class="button-bar">
         <button id="btn-top">Ditt førerkort</button>

--- a/script.js
+++ b/script.js
@@ -146,15 +146,27 @@ function startHologram() {
   });
 
 function handleOrientationMain(e) {
-  const y = e.gamma; // -90 … 90 (left/right)
+  const y = e.gamma; // left/right
+  const x = e.beta;  // front/back
   const holo = document.getElementById('holo-main');
+  const norge = document.getElementById('line-norge');
+  const noreg = document.getElementById('line-noreg');
 
-  // Opacity ranges from 0.5 (flat) to 0.9 at ~35° right tilt
-  let opacity = 0.5;
-  if (y >= 0) {
-    opacity = Math.min(0.5 + (y / 35) * 0.4, 0.9);
+  // Spinning square opacity based on left/right tilt
+  const magY = Math.min(Math.abs(y) / 30, 1);
+  const holoOpacity = 0.4 + magY * 0.3;
+  holo.style.backgroundColor = `rgba(0, 0, 0, ${holoOpacity})`;
+
+  // Text opacity based on front/back tilt relative to upright (~90deg)
+  const diff = x - 90;
+  const magX = Math.min(Math.abs(diff) / 30, 1);
+  norge.style.opacity = '0.4';
+  noreg.style.opacity = '0.4';
+  if (diff > 0) {
+    norge.style.opacity = (0.4 + 0.3 * magX).toFixed(2);
+  } else if (diff < 0) {
+    noreg.style.opacity = (0.4 + 0.3 * magX).toFixed(2);
   }
-  holo.style.backgroundColor = `rgba(0, 0, 0, ${opacity})`;
 }
 
 function handleOrientationLicense(e) {

--- a/styles.css
+++ b/styles.css
@@ -150,6 +150,23 @@ html, body {
   animation: holo-spin 45s linear infinite;
 }
 
+#holo-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  font-size: 2rem;
+  font-weight: bold;
+  line-height: 1.2;
+  z-index: 2;
+}
+
+#holo-text div {
+  opacity: 0.4;
+  transition: opacity 0.1s ease-out;
+}
+
 @keyframes holo-spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }


### PR DESCRIPTION
## Summary
- center new NORGE/NOREG hologram text on main screen
- adapt styles for new text element
- update orientation logic to fade text and square hologram on tilt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68406a5dc2d0833199d761bce08d610e