### PR TITLE
Add holograms to license and control pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,13 @@
         <span class="bar-title">Kontroll</span>
       </div>
       <div class="container kontroll-content">
+        <div class="holo-container">
+          <div id="holo-control" class="holo-object"></div>
+        </div>
+        <div id="holo-text-control" class="holo-text">
+          <div id="ctrl-norge">NORGE</div>
+          <div id="ctrl-noreg">NOREG</div>
+        </div>
         <h2>Dagens Tall</h2>
         <div id="daily-number" class="daily-number"></div>
         <img id="qr-image" src="https://via.placeholder.com/200x200?text=QR" alt="QR kode">

--- a/script.js
+++ b/script.js
@@ -125,6 +125,9 @@ function startHologram() {
     licenseScreen.classList.remove('active');
     screen2.classList.add('active');
     window.removeEventListener('deviceorientation', handleOrientationLicense);
+    if (hasHoloPermission()) {
+      window.addEventListener('deviceorientation', handleOrientationControl);
+    }
     updateDailyNumber();
     updateTimestamp('kontroll-updated');
   });
@@ -133,6 +136,7 @@ function startHologram() {
   document.getElementById('back-from-screen2').addEventListener('click', () => {
     screen2.classList.remove('active');
     licenseScreen.classList.add('active');
+    window.removeEventListener('deviceorientation', handleOrientationControl);
     if (hasHoloPermission()) {
       window.addEventListener('deviceorientation', handleOrientationLicense);
     }
@@ -170,22 +174,32 @@ function handleOrientationMain(e) {
 }
 
 function handleOrientationLicense(e) {
-  const x = e.beta;
   const y = e.gamma;
   const holo = document.getElementById('holo-license');
+  const magY = Math.min(Math.abs(y) / 30, 1);
+  const opacity = 0.4 + magY * 0.3;
+  holo.style.backgroundColor = `rgba(0, 0, 0, ${opacity})`;
+}
 
-  holo.style.transform = `translate(-50%, -50%) rotateX(${x / 2}deg) rotateY(${y / 2}deg)`;
+function handleOrientationControl(e) {
+  const y = e.gamma;
+  const x = e.beta;
+  const holo = document.getElementById('holo-control');
+  const norge = document.getElementById('ctrl-norge');
+  const noreg = document.getElementById('ctrl-noreg');
 
-  if (x > 30) {
-    holo.style.backgroundColor = 'green';
-  } else if (x < -30) {
-    holo.style.backgroundColor = 'red';
-  } else if (y > 30) {
-    holo.style.backgroundColor = 'blue';
-  } else if (y < -30) {
-    holo.style.backgroundColor = 'purple';
-  } else {
-    holo.style.backgroundColor = 'rgba(0, 122, 255, 0.5)';
+  const magY = Math.min(Math.abs(y) / 30, 1);
+  const holoOpacity = 0.4 + magY * 0.3;
+  holo.style.backgroundColor = `rgba(0, 0, 0, ${holoOpacity})`;
+
+  const diff = x - 90;
+  const magX = Math.min(Math.abs(diff) / 30, 1);
+  norge.style.opacity = '0.4';
+  noreg.style.opacity = '0.4';
+  if (diff > 0) {
+    norge.style.opacity = (0.4 + 0.3 * magX).toFixed(2);
+  } else if (diff < 0) {
+    noreg.style.opacity = (0.4 + 0.3 * magX).toFixed(2);
   }
 }
 
@@ -217,7 +231,11 @@ function handleOrientationLicense(e) {
     m.style.backgroundColor = 'rgba(0, 0, 0, 0.5)';
     const l = document.getElementById('holo-license');
     if (l) {
-      l.style.transform = 'translate(-50%, -50%) rotateX(0deg) rotateY(0deg)';
+      l.style.backgroundColor = 'rgba(0, 0, 0, 0.5)';
+    }
+    const c = document.getElementById('holo-control');
+    if (c) {
+      c.style.backgroundColor = 'rgba(0, 0, 0, 0.5)';
     }
   }
   const observer = new MutationObserver(mutations => {

--- a/styles.css
+++ b/styles.css
@@ -139,7 +139,47 @@ html, body {
   margin: 0;
   z-index: 0;
 }
+#license-screen .holo-container {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 500px;
+  height: 500px;
+  transform: translate(-125%, 25%);
+  margin: 0;
+  z-index: 0;
+}
 #holo-main {
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  border-radius: 0;
+  top: 0;
+  left: 0;
+  transform: rotate(0deg);
+  animation: holo-spin 45s linear infinite;
+}
+#screen2 .holo-container {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 500px;
+  height: 500px;
+  transform: translate(25%, 25%);
+  margin: 0;
+  z-index: 0;
+}
+#holo-control {
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  border-radius: 0;
+  top: 0;
+  left: 0;
+  transform: rotate(0deg);
+  animation: holo-spin 45s linear infinite;
+}
+#holo-license {
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.5);
@@ -163,6 +203,21 @@ html, body {
 }
 
 #holo-text div {
+  opacity: 0.4;
+  transition: opacity 0.1s ease-out;
+}
+#holo-text-control {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  font-size: 2rem;
+  font-weight: bold;
+  line-height: 1.2;
+  z-index: 2;
+}
+#holo-text-control div {
   opacity: 0.4;
   transition: opacity 0.1s ease-out;
 }


### PR DESCRIPTION
## Summary
- mirror main-screen hologram on license screen
- show spinning square and NORGE/NOREG hologram on control page
- handle orientation events for new holograms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e9f1be3883318e4b1fba546d6f33