### PR TITLE
Fix hologram animation resets

### DIFF
--- a/script.js
+++ b/script.js
@@ -32,8 +32,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const dailyNumberEl = document.getElementById('daily-number');
 
   const tiltState = {
-    gamma: { last: null, offset: 0 },
-    beta:  { last: null, offset: 0 }
+    gamma: { last: null, base: null },
+    beta:  { last: null, base: null }
   };
 
   // Cache frequently used elements
@@ -49,30 +49,36 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function resetTiltState() {
     tiltState.gamma.last = null;
-    tiltState.gamma.offset = 0;
+    tiltState.gamma.base = null;
     tiltState.beta.last = null;
-    tiltState.beta.offset = 0;
+    tiltState.beta.base = null;
   }
 
   function updateAxis(state, value, max) {
-    if (state.last === null) {
+    if (state.base === null) {
+      state.base = value;
       state.last = value;
-      state.offset = 0;
       return 0;
     }
 
     let delta = value - state.last;
     if (delta > 180) delta -= 360;
     if (delta < -180) delta += 360;
-
-    state.offset += delta;
     state.last = value;
 
-    if (Math.abs(state.offset) < 1) state.offset = 0;
-    if (state.offset > max) state.offset = max;
-    if (state.offset < -max) state.offset = -max;
+    let diff = value - state.base;
+    if (diff > 180) diff -= 360;
+    if (diff < -180) diff += 360;
 
-    return state.offset;
+    if (Math.abs(diff) < 1) {
+      state.base = value;
+      diff = 0;
+    }
+
+    if (diff > max) diff = max;
+    if (diff < -max) diff = -max;
+
+    return diff;
   }
 
   function applyDeadZone(value, threshold = 1.5) {


### PR DESCRIPTION
## Summary
- prevent hologram opacity from jumping when hitting tilt limits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841106d06288331b642ec89917e6c5e