### PR TITLE
Restore offset-based tilt tracking

### DIFF
--- a/script.js
+++ b/script.js
@@ -64,9 +64,11 @@ document.addEventListener('DOMContentLoaded', () => {
     let delta = value - state.last;
     if (delta > 180) delta -= 360;
     if (delta < -180) delta += 360;
+    state.last = value;
+
+    if (Math.abs(delta) < 0.5) delta = 0;
 
     state.offset += delta;
-    state.last = value;
 
     if (Math.abs(state.offset) < 1) state.offset = 0;
     if (state.offset > max) state.offset = max;


### PR DESCRIPTION
## Summary
- revert tilt state to use offsets instead of base angles
- add small delta filter to smooth sensor noise

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841106d06288331b642ec89917e6c5e